### PR TITLE
Remove npm install from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM mhart/alpine-node
 COPY . /medprices-ng
 WORKDIR /medprices-ng
-RUN npm install
 RUN npm install -g serve
 EXPOSE 5000
 CMD serve -s build

--- a/deploy.sh
+++ b/deploy.sh
@@ -44,7 +44,7 @@ fi
 echo 'Creating build(this could take a while)...'
 
 # create distributable code
-echo $(npm run build)
+echo $(npm install && npm run build)
 
 echo 'Finished build'
 


### PR DESCRIPTION
#### What does this PR do?

This PR updates the Dockerfile used for deployment.

#### Description of Task to be completed?
- run `npm install` in deploy.sh before building the static site
- remove `npm install` from the Dockerfile
